### PR TITLE
Basic python3 compatibility

### DIFF
--- a/PostProcessors/HangoutsChatJSSNotifier.py
+++ b/PostProcessors/HangoutsChatJSSNotifier.py
@@ -20,14 +20,11 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-from __future__ import print_function
-import json
-import os.path
-import requests
-import subprocess
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
+import requests
+
+from autopkglib import Processor, ProcessorError
 
 # Set the webhook_url to the one provided by Hangouts Chat
 # See https://developers.google.com/hangouts/chat/how-tos/webhooks

--- a/PostProcessors/HangoutsChatJSSNotifier.py
+++ b/PostProcessors/HangoutsChatJSSNotifier.py
@@ -20,6 +20,8 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import json
 import os.path
 import requests
@@ -82,13 +84,13 @@ class HangoutsChatJSSNotifier(Processor):
             jss_policy_name = "%s" % jss_importer_summary_result["data"]["Policy"]
             jss_policy_version = "%s" % jss_importer_summary_result["data"]["Version"]
             jss_uploaded_package = "%s" % jss_importer_summary_result["data"]["Package"]
-            print "JSS address: %s" % JSS_URL
-            print "Title: %s" % prod_name
-            print "Policy: %s" % jss_policy_name
-            print "Version: %s" % jss_policy_version
-            print "Category: %s" % category
-            print "Policy Category: %s" % policy_category
-            print "Package: %s" % jss_uploaded_package
+            print("JSS address: %s" % JSS_URL)
+            print("Title: %s" % prod_name)
+            print("Policy: %s" % jss_policy_name)
+            print("Version: %s" % jss_policy_version)
+            print("Category: %s" % category)
+            print("Policy Category: %s" % policy_category)
+            print("Package: %s" % jss_uploaded_package)
 
             hangoutschat_data = {
                 "cards": [

--- a/PostProcessors/HangoutsChatNotifier.py
+++ b/PostProcessors/HangoutsChatNotifier.py
@@ -21,12 +21,10 @@
 
 
 from __future__ import absolute_import
-import json
-import os.path
-import requests
-import subprocess
-from autopkglib import Processor, ProcessorError
 
+import requests
+
+from autopkglib import Processor, ProcessorError
 
 # Set the webhook_url to the one provided by Hangouts Chat
 # See https://developers.google.com/hangouts/chat/how-tos/webhooks

--- a/PostProcessors/HangoutsChatNotifier.py
+++ b/PostProcessors/HangoutsChatNotifier.py
@@ -20,6 +20,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import json
 import os.path
 import requests


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.