### PR TITLE
Adjust AppPkgCreator arguments

### DIFF
--- a/TOPCAT/TOPCAT.pkg.recipe
+++ b/TOPCAT/TOPCAT.pkg.recipe
@@ -48,8 +48,6 @@
             <string>Uses the 'output_string' var from previous proccessor as the version number</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
                 <key>version</key>
                 <string>%output_string%</string>
             </dict>


### PR DESCRIPTION
`dmg_path` is not a valid [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) argument.