### PR TITLE
Update for Hudl/SportsCode: HudlSportscode and URL Parsing

### DIFF
--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads latest Hudl Sportscode disk image.</string>
+    <key>Identifier</key>
+    <string>com.github.haircut.download.HudlSportscode</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>HudlSportscode</string>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.hudl.com/downloads/elite</string>
+        <key>USER_AGENT</key>
+        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+                <key>re_pattern</key>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/HudlSportscode\d+?\.\d+?\.\d+?\.dmg\.zip\?mtime=.*?)"</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
+                </dict>
+                <key>result_output_var_name</key>
+                <string>url</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/Hudl Sportscode.app</string>
+                <key>requirement</key>
+                <string>identifier "com.hudl.Sportscode64" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
+                <key>strict_verification</key>
+                <true />
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Hudl/HudlSportscode.pkg.recipe
+++ b/Hudl/HudlSportscode.pkg.recipe
@@ -35,6 +35,8 @@
             <dict>
                 <key>app_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/Hudl Sportscode.app</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/Hudl/HudlSportscode.pkg.recipe
+++ b/Hudl/HudlSportscode.pkg.recipe
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads latest Hudl Sportscode disk image and creates a package.</string>
+    <key>Identifier</key>
+    <string>com.github.haircut.pkg.HudlSportscode</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>HudlSportscode</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.haircut.download.HudlSportscode</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>AppDmgVersioner</string>
+            <key>Comment</key>
+            <string>The parent download recipe already unzips the .dmg.zip provided by the vendor, so we just reuse that instead of unarchiving again.</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>AppPkgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/Hudl Sportscode.app</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>SportsCode</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.hudl.com/elite/downloads</string>
+        <string>https://www.hudl.com/downloads/elite</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode.dmg.zip\?mtime=.*?)"</string>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode\d+?\.\d+?\.\d+?\.dmg.zip\?mtime=.*?)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>


### PR DESCRIPTION
Adds 64-Bit version of SportsCode called "Hudl Sportscode" and updates URL schema.

I have tested all changes on my production AutoPkg server:


HudlSportscode.pkg
```
% autopkg run HudlSportscode.pkg                                    
Processing HudlSportscode.pkg...

The following packages were built:
    Identifier             Version  Pkg Path                                                                                              
    ----------             -------  --------                                                                                              
    com.hudl.Sportscode64  12.2.35  <redacted>/Library/AutoPkg/Cache/com.github.haircut.pkg.HudlSportscode/HudlSportscode-12.2.35.pkg
```

SportsCode.pkg
```
% autopkg run ~/Library/AutoPkg/RecipeRepos/com.github.primalcurve.haircut-recipes/Hudl/SportsCode.pkg.recipe
Processing <redacted>/Library/AutoPkg/RecipeRepos/com.github.primalcurve.haircut-recipes/Hudl/SportsCode.pkg.recipe...

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    <redacted>/Library/AutoPkg/Cache/com.github.haircut.pkg.SportsCode/downloads/SportsCode.dmg.zip  

The following packages were built:
    Identifier              Version  Pkg Path                                                                                     
    ----------              -------  --------                                                                                     
    com.vigital.SportsCode  11.3.0   <redacted>/Library/AutoPkg/Cache/com.github.haircut.pkg.SportsCode/SportsCode-11.3.0.pkg
```