### PR TITLE
Hudl Sportscode Fixes

### DIFF
--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/HudlSportscode\d+?\.\d+?\.\d+?\.dmg\.zip\?mtime=.*?)"</string>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/HudlSportscode-?\d+?(\.|-)\d+?(\.|-)\d+?\.dmg\.zip\?mtime=.*?)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>

--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -67,11 +67,20 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg/%APP_NAME%.app</string>
+                <string>%found_filename%</string>
                 <key>requirement</key>
                 <string>identifier "com.hudl.Sportscode64" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
                 <key>strict_verification</key>

--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -80,7 +80,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%found_filename%</string>
+                <string>%found_filename%/%APP_NAME%.app</string>
                 <key>requirement</key>
                 <string>identifier "com.hudl.Sportscode64" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
                 <key>strict_verification</key>

--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>HudlSportscode</string>
+        <key>APP_NAME</key>
+        <string>Hudl Sportscode</string>
         <key>DOWNLOAD_URL</key>
         <string>https://www.hudl.com/downloads/elite</string>
         <key>USER_AGENT</key>
@@ -27,7 +29,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/HudlSportscode-?\d+?(\.|-)\d+?(\.|-)\d+?\.dmg\.zip\?mtime=.*?)"</string>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/HudlSportscode-?\d+?[\.-]\d+?[\.-]\d+?\.dmg\.zip\?mtime=.*?)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
@@ -69,7 +71,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/Hudl Sportscode.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg/%APP_NAME%.app</string>
                 <key>requirement</key>
                 <string>identifier "com.hudl.Sportscode64" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
                 <key>strict_verification</key>

--- a/Hudl/HudlSportscode.pkg.recipe
+++ b/Hudl/HudlSportscode.pkg.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>HudlSportscode</string>
+        <key>APP_NAME</key>
+        <string>Hudl Sportscode</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -19,13 +21,20 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>AppDmgVersioner</string>
-            <key>Comment</key>
-            <string>The parent download recipe already unzips the .dmg.zip provided by the vendor, so we just reuse that instead of unarchiving again.</string>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
+                <string>%found_filename%</string>
             </dict>
         </dict>
         <dict>
@@ -34,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>app_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/Hudl Sportscode.app</string>
+                <string>%found_filename%/%APP_NAME%.app</string>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode-?\d+?(\.|-)\d+?(\.|-)\d+?\.dmg\.zip\?mtime=.*?)"</string>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode-?\d+?[\.-]\d+?[\.-]\d+?\.dmg\.zip\?mtime=.*?)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
@@ -69,7 +69,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/SportsCode.dmg/SportsCode.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg/%NAME%.app</string>
                 <key>requirement</key>
                 <string>identifier "com.vigital.SportsCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
                 <key>strict_verification</key>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode\d+?\.\d+?\.\d+?\.dmg.zip\?mtime=.*?)"</string>
+                <string>href="(https://hudl-content.s3.amazonaws.com/craft/elite/downloads/SportsCode-?\d+?(\.|-)\d+?(\.|-)\d+?\.dmg\.zip\?mtime=.*?)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -65,11 +65,20 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg/%NAME%.app</string>
+                <string>%found_filename%/%NAME%.app</string>
                 <key>requirement</key>
                 <string>identifier "com.vigital.SportsCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4M6T2C723P"</string>
                 <key>strict_verification</key>

--- a/Hudl/SportsCode.pkg.recipe
+++ b/Hudl/SportsCode.pkg.recipe
@@ -19,13 +19,22 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%*.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>AppDmgVersioner</string>
             <key>Comment</key>
             <string>The parent download recipe already unzips the .dmg.zip provided by the vendor, so we just reuse that instead of unarchiving again.</string>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
+                <string>%found_filename%</string>
             </dict>
         </dict>
         <dict>
@@ -34,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>app_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/SportsCode.dmg/SportsCode.app</string>
+                <string>%found_filename%/%NAME%.app</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Looks like Hudl updated their pipelines to output some new, fancy filenames. These fixes include updates to the Regular Expression as well as using the `FileFinder` processor to find their fancy new DMGs.

I have tested the changes on my own production AutoPkg instance:
```
% autopkg run HudlSportscode.pkg
Processing HudlSportscode.pkg...

The following packages were built:
    Identifier             Version  Pkg Path
    ----------             -------  --------
    com.hudl.Sportscode64  12.2.36  /Users/<redacted>/Library/AutoPkg/Cache/local.pkg.HudlSportscode/HudlSportscode-12.2.36.pkg
```

```
% autopkg run SportsCode.pkg
Processing SportsCode.pkg...

The following packages were built:
    Identifier              Version  Pkg Path
    ----------              -------  --------
    com.vigital.SportsCode  11.3.0   /Users/<redacted>/Library/AutoPkg/Cache/local.pkg.SportsCode/SportsCode-11.3.0.pkg
```

Remember, these are 🏆 🏆 🏆 ELITE DOWNLOADS 🏆 🏆 🏆