### PR TITLE
Fixes to pkg recipe

### DIFF
--- a/texthelp/ReadWrite7.pkg.recipe
+++ b/texthelp/ReadWrite7.pkg.recipe
@@ -19,11 +19,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
+            <string>Versioner</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Read&amp;Write.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>app_path</key>
-                <string>%dmg_path%/Read&amp;Write.app</string>
+                <string>%RECIPE_CACHE_DIR%/Applications/Read&amp;Write.app</string>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>


### PR DESCRIPTION
AppDmgVersioner was failing to mount. Have changed this to Versioner and point towards the unarchived app from the download recipe. 

Also changed the app_path in AppPkgCreator to point towards the unarchived app