### PR TITLE
cura lulzbot updated package creation

### DIFF
--- a/lulzbot/cura-lulzbot.pkg.recipe
+++ b/lulzbot/cura-lulzbot.pkg.recipe
@@ -19,65 +19,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
+            <string>AppPkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/cura-lulzbot.app</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/cura-lulzbot.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>id</key>
-                    <string>org.pythonmac.unspecified.cura-lulzbot</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
+                <key>app_path</key>
+                <string>%pathname%/*.app</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Removed other processors. Now just uses AppPkgCreator. Fixes the following error. 

```
 Error in local.jamf.CuraLulzbotEdition: Processor: Copier: Error: Error processing path '/private/tmp/dmg.S40fXJ/cura-lulzbot.app' with glob. 
```

