### PR TITLE
Update PreForm.download.recipe

### DIFF
--- a/Formlabs/PreForm.download.recipe
+++ b/Formlabs/PreForm.download.recipe
@@ -17,24 +17,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>re_pattern</key>
-                <string>(https://downloads\.formlabs\.com/PreForm/Release/([0-9]+(\.[0-9]+)+)/PreForm_mac_([0-9]+(\.[0-9]+)+).*?\.dmg)</string>
-                <key>result_output_var_name</key>
-                <string>match</string>
-                <key>url</key>
-                <string>https://formlabs.com/download-preform-mac/</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%match%</string>
+                <string>https://formlabs.com/download-preform-mac/</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>


### PR DESCRIPTION
Update to remove URLTextSearcher processor because it references a page that no longer is useful and the url "https://formlabs.com/download-preform-mac/" now downloads the latest version automatically.