### PR TITLE
Fix TOPCAT recipes

### DIFF
--- a/TOPCAT/TOPCAT.download.recipe
+++ b/TOPCAT/TOPCAT.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>TOPCAT</string>
         <key>url</key>
-        <string>http://www.star.bris.ac.uk/~mbt/topcat/topcat-full.dmg</string>
+        <string>https://www.star.bris.ac.uk/~mbt/topcat/topcat-all.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>


### PR DESCRIPTION
This PR fixes the download method used for the TOPCAT recipes.

Verbose recipe run output:

```
% autopkg run -vvq 'TOPCAT/TOPCAT.download.recipe'
Processing TOPCAT/TOPCAT.download.recipe...
WARNING: TOPCAT/TOPCAT.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'TOPCAT.dmg',
           'url': 'https://www.star.bris.ac.uk/~mbt/topcat/topcat-all.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 08 Nov 2024 10:21:49 GMT
URLDownloader: Storing new ETag header: "7253706-626641e72ab08"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.download.TOPCAT/downloads/TOPCAT.dmg
{'Output': {'download_changed': True,
            'etag': '"7253706-626641e72ab08"',
            'last_modified': 'Fri, 08 Nov 2024 10:21:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.download.TOPCAT/downloads/TOPCAT.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.TOPCAT/downloads/TOPCAT.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.download.TOPCAT/receipts/TOPCAT.download-receipt-20241226-123541.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.haircut.download.TOPCAT/downloads/TOPCAT.dmg
```