### PR TITLE
Fix LoggerLite recipes and add code signature verification

### DIFF
--- a/Vernier/LoggerLite.download.recipe
+++ b/Vernier/LoggerLite.download.recipe
@@ -17,24 +17,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.vernier.com/products/software/logger-lite/</string>
-                <key>re_pattern</key>
-                <string>&lt;a href="(http://www2.vernier.com/download/.*?.dmg)" class="ga-software-download button download" data-title="Click to download"&gt;</string>
-                <key>result_output_var_name</key>
-                <string>dmg_url</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%dmg_url%</string>
+                <string>https://www.vernier.com/download-logger-lite-mac</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>
@@ -42,6 +29,21 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Install Logger Lite.pkg</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Vernier Software &amp; Technology (75WN2B2WR8)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR updates the download method used for LoggerLite, and adds code signature verification of the downloaded package.

```
% autopkg run -vvq 'Vernier/LoggerLite.download.recipe'
Processing Vernier/LoggerLite.download.recipe...
WARNING: Vernier/LoggerLite.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'LoggerLite.dmg',
           'url': 'https://www.vernier.com/download-logger-lite-mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 02 May 2018 23:32:06 GMT
URLDownloader: Storing new ETag header: "d5511367bc34b61af3d58d6ad11480d4-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg
{'Output': {'download_changed': True,
            'etag': '"d5511367bc34b61af3d58d6ad11480d4-2"',
            'last_modified': 'Wed, 02 May 2018 23:32:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Vernier '
                                        'Software & Technology (75WN2B2WR8)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg/Install '
                         'Logger Lite.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Logger Lite.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2018-04-13 17:32:00 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Vernier Software & Technology (75WN2B2WR8)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            9E AB FE 12 33 33 D9 DC 94 AC 1F E3 AB AF 13 FD 07 D8 F4 3E 91 4F
CodeSignatureVerifier:            CB AB 68 23 44 F2 FD B2 33 72
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/receipts/LoggerLite.download-receipt-20241226-123151.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.haircut.download.LoggerLite/downloads/LoggerLite.dmg
```
