### PR TITLE
Fix LAME-64bit recipes and add code signature verification

### DIFF
--- a/LAME/LAME-64bit.download.recipe
+++ b/LAME/LAME-64bit.download.recipe
@@ -37,6 +37,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Arturo Busleiman (AWYMBCFHTX)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/LAME/LAME-64bit.download.recipe
+++ b/LAME/LAME-64bit.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>LAME-64bit</string>
-        <key>url</key>
-        <string>https://lame.buanzo.org/lame_64bit_osx.pkg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -24,6 +22,15 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
+                <key>url</key>
+                <string>https://lame.buanzo.org/lame_64bit_osx.pkg</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15</string>
+                    <key>referer</key>
+                    <string>https://lame.buanzo.org/</string>
+                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR updates the download method for the 64-bit version of the LAME encoding library. A user-agent and referer header appears to be required for the download to succeed.

I've also added code signature verification on the resulting pkg file.

Verbose recipe run output:

```
% autopkg run -vvq 'LAME/LAME-64bit.download.recipe'
Processing LAME/LAME-64bit.download.recipe...
WARNING: LAME/LAME-64bit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'LAME-64bit.pkg',
           'request_headers': {'referer': 'https://lame.buanzo.org/',
                               'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'url': 'https://lame.buanzo.org/lame_64bit_osx.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/downloads/LAME-64bit.pkg
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/downloads/LAME-64bit.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/downloads/LAME-64bit.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Arturo '
                                        'Busleiman (AWYMBCFHTX)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/downloads/LAME-64bit.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "LAME-64bit.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2019-03-07 18:07:46 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Arturo Busleiman (AWYMBCFHTX)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1A 29 1B DE D3 F2 78 0F 63 FF 19 3F 80 CB A5 B9 54 D3 A6 C0 70 26
CodeSignatureVerifier:            52 34 10 CD 12 06 50 8E AC 62
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/receipts/LAME-64bit.download-receipt-20241226-122725.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.haircut.download.LAME-64bit/downloads/LAME-64bit.pkg
```
