### PR TITLE
Deprecate iMol recipes

### DIFF
--- a/iMol/iMol.download.recipe
+++ b/iMol/iMol.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>PIRX iMol hasn't been updated since 2007. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the iMol family of recipes, since the software hasn't been updated since 2007 and the current download link is returning an HTTP 500 error.