### PR TITLE
Fix Descript recipes and add ARCH and PLATFORM input variables

### DIFF
--- a/Descript/Descript.download.recipe
+++ b/Descript/Descript.download.recipe
@@ -3,15 +3,24 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Descript.</string>
+	<string>Downloads the latest version of Descript.
+
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "arm64" (Apple Silicon)
+
+The only verified PLATFORM value is "mac".
+</string>
 	<key>Identifier</key>
 	<string>com.github.haircut.download.Descript</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Descript</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://rink.hockeyapp.net/api/2/apps/327f799abcbc46edb477c547be0978c5</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
+		<key>PLATFORM</key>
+		<string>mac</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -20,17 +29,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>https://web.descript.com/download?platform=%PLATFORM%&amp;arch=%ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -43,9 +45,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Descript.app</string>
+				<string>%pathname%/Descript.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.descript.Descript" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D4CJQGP2T7)</string>
+				<string>identifier "com.descript.beachcube" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D4CJQGP2T7</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Descript/Descript.pkg.recipe
+++ b/Descript/Descript.pkg.recipe
@@ -20,15 +20,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
-			</dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>app_path</key>
 				<string>%pathname%/Descript.app</string>
 			</dict>


### PR DESCRIPTION
This PR updates the Descript recipes to use the same URL used by the vendor's "installer app," since the previous Sparkle feed is no longer available.

I've also added an ARCH input variable that can be used for selecting which architecture to download.

A PLATFORM input variable has also been added, but I didn't test with any value other than `mac`.

Verbose recipe run output with default (Intel) architecture specified:

```
% autopkg run -vvq Descript.{download,pkg}.recipe
Processing Descript.download.recipe...
WARNING: Descript.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Descript.dmg',
           'url': 'https://web.descript.com/download?platform=mac&arch=x86_64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 19:24:24 GMT
URLDownloader: Storing new ETag header: "0659bacf22599cb694ea44553a1c4906-30"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
{'Output': {'download_changed': True,
            'etag': '"0659bacf22599cb694ea44553a1c4906-30"',
            'last_modified': 'Wed, 11 Dec 2024 19:24:24 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg/Descript.app',
           'requirement': 'identifier "com.descript.beachcube" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'D4CJQGP2T7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.TbWbfT/Descript.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.TbWbfT/Descript.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.TbWbfT/Descript.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/receipts/Descript.download-receipt-20241226-121142.plist
Processing Descript.pkg.recipe...
WARNING: Descript.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Descript.dmg',
           'url': 'https://web.descript.com/download?platform=mac&arch=x86_64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 19:24:24 GMT
URLDownloader: Storing new ETag header: "0659bacf22599cb694ea44553a1c4906-30"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
{'Output': {'download_changed': True,
            'etag': '"0659bacf22599cb694ea44553a1c4906-30"',
            'last_modified': 'Wed, 11 Dec 2024 19:24:24 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg/Descript.app',
           'requirement': 'identifier "com.descript.beachcube" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'D4CJQGP2T7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.cf7SMS/Descript.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.cf7SMS/Descript.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.cf7SMS/Descript.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg/Descript.app'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
AppPkgCreator: Version: 104.0.0-release.20241211.6763
AppPkgCreator: BundleID: com.descript.beachcube
AppPkgCreator: Copied /private/tmp/dmg.MQrFaZ/Descript.app to ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/payload/Applications/Descript.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.descript.beachcube',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/Descript-104.0.0-release.20241211.6763.pkg',
                                                        'version': '104.0.0-release.20241211.6763'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '104.0.0-release.20241211.6763'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/receipts/Descript.pkg-receipt-20241226-121215.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
    ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg

The following packages were built:
    Identifier              Version                        Pkg Path
    ----------              -------                        --------
    com.descript.beachcube  104.0.0-release.20241211.6763  ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/Descript-104.0.0-release.20241211.6763.pkg
```

Verbose recipe run output with Apple Silicon architecture specified:

```
% autopkg run -vvq Descript.{download,pkg}.recipe -k ARCH=arm64
Processing Descript.download.recipe...
WARNING: Descript.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Descript.dmg',
           'url': 'https://web.descript.com/download?platform=mac&arch=arm64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 19:24:24 GMT
URLDownloader: Storing new ETag header: "b6c5a34b9f1f847688bfcc64ad4c5c55-27"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
{'Output': {'download_changed': True,
            'etag': '"b6c5a34b9f1f847688bfcc64ad4c5c55-27"',
            'last_modified': 'Wed, 11 Dec 2024 19:24:24 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg/Descript.app',
           'requirement': 'identifier "com.descript.beachcube" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'D4CJQGP2T7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.iQUtdT/Descript.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.iQUtdT/Descript.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.iQUtdT/Descript.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/receipts/Descript.download-receipt-20241226-121232.plist
Processing Descript.pkg.recipe...
WARNING: Descript.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Descript.dmg',
           'url': 'https://web.descript.com/download?platform=mac&arch=arm64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 19:24:24 GMT
URLDownloader: Storing new ETag header: "b6c5a34b9f1f847688bfcc64ad4c5c55-27"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
{'Output': {'download_changed': True,
            'etag': '"b6c5a34b9f1f847688bfcc64ad4c5c55-27"',
            'last_modified': 'Wed, 11 Dec 2024 19:24:24 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg/Descript.app',
           'requirement': 'identifier "com.descript.beachcube" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'D4CJQGP2T7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.0rrFdO/Descript.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.0rrFdO/Descript.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.0rrFdO/Descript.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg/Descript.app'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
AppPkgCreator: Version: 104.0.0-release.20241211.6763
AppPkgCreator: BundleID: com.descript.beachcube
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/Descript-104.0.0-release.20241211.6763.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '104.0.0-release.20241211.6763'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/receipts/Descript.pkg-receipt-20241226-121246.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.haircut.download.Descript/downloads/Descript.dmg
    ~/Library/AutoPkg/Cache/com.github.haircut.pkg.Descript/downloads/Descript.dmg
```
