### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/avidemux/avidemux.download.recipe
+++ b/avidemux/avidemux.download.recipe
@@ -14,7 +14,7 @@
         <key>NAME</key>
         <string>avidemux</string>
         <key>SEARCH_URL</key>
-        <string>http://www.fosshub.com/Avidemux.html</string>
+        <string>https://www.fosshub.com/Avidemux.html</string>
         <key>SEARCH_PATTERN</key>
         <string>\/Avidemux.html.(Avidemux_([0-9].[0-9].[0-9])_Sierra_64Bits_Qt5)\.dmg</string>
         <key>SEARCH_PATTERN2</key>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.fosshub.com/Avidemux.html</string>
+                <string>https://www.fosshub.com/Avidemux.html</string>
                 <key>re_pattern</key>
                 <string>%SEARCH_PATTERN%</string>
             </dict>
@@ -43,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.fosshub.com/Avidemux.html/%match%.dmg</string>
+                <string>https://www.fosshub.com/Avidemux.html/%match%.dmg</string>
                 <key>re_pattern</key>
                 <string>%SEARCH_PATTERN2%</string>
             </dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._