### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Calibre/Calibre.pkg.recipe
+++ b/Calibre/Calibre.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>net.kovidgoyal.calibre</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Formlabs/PreForm.pkg.recipe
+++ b/Formlabs/PreForm.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.formlabs.PreForm</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/FreeMacSoft/AppCleaner.pkg.recipe
+++ b/FreeMacSoft/AppCleaner.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>net.freemacsoft.AppCleaner</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Microsoft/MinecraftEdu-ClassroomMode.pkg.recipe
+++ b/Microsoft/MinecraftEdu-ClassroomMode.pkg.recipe
@@ -66,9 +66,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/Microsoft/MinecraftEdu-Client.pkg.recipe
+++ b/Microsoft/MinecraftEdu-Client.pkg.recipe
@@ -66,9 +66,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/Microsoft/MinecraftEdu-CodeConnection.pkg.recipe
+++ b/Microsoft/MinecraftEdu-CodeConnection.pkg.recipe
@@ -66,9 +66,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/NationalCenterForAccessibleMedia/CADET.pkg.recipe
+++ b/NationalCenterForAccessibleMedia/CADET.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>org.wgbh.ncam.cadet</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/SmithsonianInstitute/SAOImageDS9-app.pkg.recipe
+++ b/SmithsonianInstitute/SAOImageDS9-app.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.sao.SAOImageDS9</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Techsmith/Jing.pkg.recipe
+++ b/Techsmith/Jing.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.techSmith.jing</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Unidata/CAVE.pkg.recipe
+++ b/Unidata/CAVE.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>edu.ucar.unidata.CAVE</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Zotero/Zotero.pkg.recipe
+++ b/Zotero/Zotero.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.zotero.zotero.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/avidemux/avidemux.pkg.recipe
+++ b/avidemux/avidemux.pkg.recipe
@@ -73,8 +73,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._