### PR TITLE
Change MinecraftEdu.pkg parent recipe

### DIFF
--- a/Microsoft/MinecraftEdu-Client.download.recipe
+++ b/Microsoft/MinecraftEdu-Client.download.recipe
@@ -16,9 +16,18 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the MinecraftEducation recipes in the aysiu-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Microsoft/MinecraftEdu-Client.pkg.recipe
+++ b/Microsoft/MinecraftEdu-Client.pkg.recipe
@@ -14,86 +14,12 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.haircut.download.MinecraftEdu-Client</string>
+    <string>com.github.aysiu.download.MinecraftEducation</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/minecraftpe.app</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/minecraftpe.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                     <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                </array>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+            <string>AppPkgCreator</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
The Minecraft Edu download in this repo is redundant with the earlier-created equivalent in the aysiu-recipes repo. This PR adjusts the pkg parent to point to that one, and deprecates the download recipe in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

Verbose pkg recipe run after change:

```
% autopkg run -vvq 'haircut-recipes/Microsoft/MinecraftEdu-Client.pkg.recipe'
Processing haircut-recipes/Microsoft/MinecraftEdu-Client.pkg.recipe...
WARNING: haircut-recipes/Microsoft/MinecraftEdu-Client.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'MinecraftEdu-Client.dmg',
           'url': 'https://aka.ms/meeclientmacos'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg/minecraft-edu.app',
           'requirement': 'identifier "com.microsoft.minecraft-edu" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UBF8T346G9'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3RDU7D/minecraft-edu.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3RDU7D/minecraft-edu.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3RDU7D/minecraft-edu.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg/minecraft-edu.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg
Versioner: Found version 1.21.92 in file ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg/minecraft-edu.app/Contents/Info.plist
{'Output': {'version': '1.21.92'}}
AppPkgCreator
{'Input': {'version': '1.21.92'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/downloads/MinecraftEdu-Client.dmg
AppPkgCreator: Using path '/private/tmp/dmg.x51i5m/minecraft-edu.app' matched from globbed '/private/tmp/dmg.x51i5m/*.app'.
AppPkgCreator: BundleID: com.microsoft.minecraft-edu
AppPkgCreator: Copied /private/tmp/dmg.x51i5m/minecraft-edu.app to ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/payload/Applications/minecraft-edu.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.microsoft.minecraft-edu',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/minecraft-edu-1.21.92.pkg',
                                                        'version': '1.21.92'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.21.92'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/receipts/MinecraftEdu-Client.pkg-receipt-20251026-215952.plist

The following packages were built:
    Identifier                   Version  Pkg Path                                                                                                  
    ----------                   -------  --------                                                                                                  
    com.microsoft.minecraft-edu  1.21.92  ~/Library/AutoPkg/Cache/com.github.haircut.pkg.MinecraftEdu-Client/minecraft-edu-1.21.92.pkg
```